### PR TITLE
feat(useMatomo hook): add useCallback for returned methods

### DIFF
--- a/src/useMatomo.js
+++ b/src/useMatomo.js
@@ -1,17 +1,39 @@
-import { useContext } from 'react';
+import { useCallback, useContext } from 'react';
 
 import { MatomoContext } from './MatomoProvider';
 
 const useMatomo = () => {
   const instance = useContext(MatomoContext);
 
-  const trackAppStart = () => instance.trackAppStart && instance.trackAppStart();
-  const trackScreenView = (params) => instance.trackScreenView && instance.trackScreenView(params);
-  const trackAction = (params) => instance.trackAction && instance.trackAction(params);
-  const trackEvent = (params) => instance.trackEvent && instance.trackEvent(params);
-  const trackSiteSearch = (params) => instance.trackSiteSearch && instance.trackSiteSearch(params);
-  const trackLink = (params) => instance.trackLink && instance.trackLink(params);
-  const trackDownload = (params) => instance.trackDownload && instance.trackDownload(params);
+  const trackAppStart = useCallback(() => instance.trackAppStart && instance.trackAppStart(), [
+    instance
+  ]);
+
+  const trackScreenView = useCallback(
+    (params) => instance.trackScreenView && instance.trackScreenView(params),
+    [instance]
+  );
+
+  const trackAction = useCallback(
+    (params) => instance.trackAction && instance.trackAction(params),
+    [instance]
+  );
+
+  const trackEvent = useCallback((params) => instance.trackEvent && instance.trackEvent(params), [
+    instance
+  ]);
+
+  const trackSiteSearch = useCallback(
+    (params) => instance.trackSiteSearch && instance.trackSiteSearch(params),
+    [instance]
+  );
+
+  const trackLink = useCallback((params) => instance.trackLink && instance.trackLink(params), []);
+
+  const trackDownload = useCallback(
+    (params) => instance.trackDownload && instance.trackDownload(params),
+    [instance]
+  );
 
   return {
     trackAppStart,

--- a/src/useMatomo.js
+++ b/src/useMatomo.js
@@ -1,49 +1,22 @@
-import { useCallback, useContext } from 'react';
+import { useContext, useMemo } from 'react';
 
 import { MatomoContext } from './MatomoProvider';
 
 const useMatomo = () => {
   const instance = useContext(MatomoContext);
 
-  const trackAppStart = useCallback(() => instance.trackAppStart && instance.trackAppStart(), [
-    instance
-  ]);
-
-  const trackScreenView = useCallback(
-    (params) => instance.trackScreenView && instance.trackScreenView(params),
+  return useMemo(
+    () => ({
+      trackAppStart: () => instance.trackAppStart && instance.trackAppStart(),
+      trackScreenView: (params) => instance.trackScreenView && instance.trackScreenView(params),
+      trackAction: (params) => instance.trackAction && instance.trackAction(params),
+      trackEvent: (params) => instance.trackEvent && instance.trackEvent(params),
+      trackSiteSearch: (params) => instance.trackSiteSearch && instance.trackSiteSearch(params),
+      trackLink: (params) => instance.trackLink && instance.trackLink(params),
+      trackDownload: (params) => instance.trackDownload && instance.trackDownload(params)
+    }),
     [instance]
   );
-
-  const trackAction = useCallback(
-    (params) => instance.trackAction && instance.trackAction(params),
-    [instance]
-  );
-
-  const trackEvent = useCallback((params) => instance.trackEvent && instance.trackEvent(params), [
-    instance
-  ]);
-
-  const trackSiteSearch = useCallback(
-    (params) => instance.trackSiteSearch && instance.trackSiteSearch(params),
-    [instance]
-  );
-
-  const trackLink = useCallback((params) => instance.trackLink && instance.trackLink(params), []);
-
-  const trackDownload = useCallback(
-    (params) => instance.trackDownload && instance.trackDownload(params),
-    [instance]
-  );
-
-  return {
-    trackAppStart,
-    trackScreenView,
-    trackAction,
-    trackEvent,
-    trackSiteSearch,
-    trackLink,
-    trackDownload
-  };
 };
 
 export default useMatomo;


### PR DESCRIPTION
- added `useCallback` to not recreate the methods on each render of the screens they are used in

Closes #4

@digorath have you thought this way when created the issue?

This version can be tested with an app using the package while temporary installing the branch version with `yarn add ../../path/to/local/matomo-tracker-react-native`.