### PR TITLE
feat(optional user info): pass more params to Matomo Tracking HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,29 +85,35 @@ Method              | Default                | Description
 
 The following methods are available with the `useMatomo` hook.
 
-### trackAppStart()
+### trackAppStart({ userInfo = {} } = {})
 
 Tracks app start as action with prefixed 'App' category: `App / start`.
 
-### trackScreenView(name)
+Param      | Description
+---------- | -----------
+`userInfo` | Optional data used for tracking different user info, see https://developer.matomo.org/api-reference/tracking-api#optional-user-info.
+
+### trackScreenView({ name, userInfo = {} })
 
 Tracks screen view as action with prefixed 'Screen' category: `Screen / ${name}`
 
-Param  | Description
------- | -----------
-`name` | The title of the action being tracked. It is possible to use slashes / to set one or several categories for this action. For example, Help / Feedback will create the Action Feedback in the category Help.
+Param      | Description
+---------- | -----------
+`name`     | The title of the action being tracked. It is possible to use slashes / to set one or several categories for this action. For example, Help / Feedback will create the Action Feedback in the category Help.
+`userInfo` | Optional data used for tracking different user info, see https://developer.matomo.org/api-reference/tracking-api#optional-user-info.
 
-### trackAction(name)
+### trackAction({ name, userInfo = {} })
 
 Tracks actions
 
 Doc: https://developer.matomo.org/api-reference/tracking-api#recommended-parameters
 
-Param  | Description
------- | -----------
-`name` | The title of the action being tracked. It is possible to use slashes / to set one or several categories for this action. For example, Help / Feedback will create the Action Feedback in the category Help.
+Param      | Description
+---------- | -----------
+`name`     | The title of the action being tracked. It is possible to use slashes / to set one or several categories for this action. For example, Help / Feedback will create the Action Feedback in the category Help.
+`userInfo` | Optional data used for tracking different user info, see https://developer.matomo.org/api-reference/tracking-api#optional-user-info.
 
-### trackEvent({ category, action, name, value })
+### trackEvent({ category, action, name, value, userInfo = {} })
 
 Tracks custom events
 
@@ -119,8 +125,9 @@ Param      | Description
 `action`   | The event action. Must not be empty. (eg. Play, Pause, Duration, Add Playlist, Downloaded, Clicked...)
 `name`     | The event name. (eg. a Movie name, or Song name, or File name...)
 `value`    | The event value. Must be a float or integer value (numeric), not a string.
+`userInfo` | Optional data used for tracking different user info, see https://developer.matomo.org/api-reference/tracking-api#optional-user-info.
 
-### trackSiteSearch({ keyword, category, count })
+### trackSiteSearch({ keyword, category, count, userInfo = {} })
 
 Tracks site search
 
@@ -131,18 +138,20 @@ Param       | Description
 `keyword`   | The Site Search keyword. When specified, the request will not be tracked as a normal pageview but will instead be tracked as a Site Search request.
 `category`  | When `keyword` is specified, you can optionally specify a search category with this parameter.
 `count`     | When `keyword` is specified, it is also recommended setting the search_count to the number of search results displayed on the results page. When keywords are tracked with &search_count=0 they will appear in the "No Result Search Keyword" report.
+`userInfo`  | Optional data used for tracking different user info, see https://developer.matomo.org/api-reference/tracking-api#optional-user-info.
 
-### trackLink(link)
+### trackLink({ link, userInfo = {} })
 
 Tracks outgoing links to other sites
 
 Doc: https://developer.matomo.org/api-reference/tracking-api#optional-action-info-measure-page-view-outlink-download-site-search
 
-Param  | Description
------- | -----------
-`link` | An external URL the user has opened. Used for tracking outlink clicks.
+Param      | Description
+---------- | -----------
+`link`     | An external URL the user has opened. Used for tracking outlink clicks.
+`userInfo` | Optional data used for tracking different user info, see https://developer.matomo.org/api-reference/tracking-api#optional-user-info.
 
-### trackDownload(download)
+### trackDownload({ download, userInfo = {} })
 
 Tracks downloads
 
@@ -151,6 +160,7 @@ Doc: https://developer.matomo.org/api-reference/tracking-api#optional-action-inf
 Param      | Description
 ---------- | -----------
 `download` | URL of a file the user has downloaded. Used for tracking downloads.
+`userInfo` | Optional data used for tracking different user info, see https://developer.matomo.org/api-reference/tracking-api#optional-user-info.
 
 
 ## Changelog

--- a/src/useMatomo.js
+++ b/src/useMatomo.js
@@ -7,7 +7,7 @@ const useMatomo = () => {
 
   return useMemo(
     () => ({
-      trackAppStart: () => instance.trackAppStart && instance.trackAppStart(),
+      trackAppStart: (params) => instance.trackAppStart && instance.trackAppStart(params),
       trackScreenView: (params) => instance.trackScreenView && instance.trackScreenView(params),
       trackAction: (params) => instance.trackAction && instance.trackAction(params),
       trackEvent: (params) => instance.trackEvent && instance.trackEvent(params),


### PR DESCRIPTION
- updated every method to get a params object with optional user info
- see https://developer.matomo.org/api-reference/tracking-api#optional-user-info for possible params
- added `send_image` - If set to 0 (send_image=0) Matomo will respond with a HTTP 204 response code instead of a GIF image
- added `'Accept-Language': lang` - This value is used to detect the visitor's country
  - take a possibly given language and delete it from the data object, as we need to pass it in the headers instead of body params, otherwise it would overwrite the 'Accept-Language' value

Resolves #3

---

With a given `Accept-Language`, Matomo can show a visitors country and language as follows:

![Bildschirmfoto 2021-07-16 um 23 38 53](https://user-images.githubusercontent.com/1942953/126011049-48f94633-0836-472d-8551-7433550661d6.png)

---

Random user info could be something like:

```js
...

const userInfo = {
  _cvar: JSON.stringify({ 1: ['App-Version', app.version] }),
  lang: device.locale,
  res: `${device.width}x${device.height}`,
  ua: device.userAgent
};

trackScreenView({ name, userInfo });

...
```

|_cvar|ua and res|
|---|---|
|![Bildschirmfoto 2021-07-16 um 23 42 10](https://user-images.githubusercontent.com/1942953/126011248-2db657bb-45aa-4bf5-bbc2-9f8c8585f5bf.png)|![Bildschirmfoto 2021-07-16 um 23 42 06](https://user-images.githubusercontent.com/1942953/126011302-3d1c3e42-fcd8-4472-a1ea-3363129a06cb.png) ![Bildschirmfoto 2021-07-16 um 23 41 58](https://user-images.githubusercontent.com/1942953/126011312-2f3a8929-c8b4-45c1-bd1a-57b69219f969.png) ![Bildschirmfoto 2021-07-16 um 23 42 01](https://user-images.githubusercontent.com/1942953/126011318-0d26e9c2-daaf-4a22-be1f-037ab6ffef6a.png)|

For getting a language in an Expo app https://docs.expo.io/versions/v42.0.0/sdk/localization/#localizationlocale can be used.
For the resolution https://docs.expo.io/versions/v42.0.0/react-native/dimensions/ or https://docs.expo.io/versions/v42.0.0/react-native/usewindowdimensions/ can be used.
For a user agent https://docs.expo.io/versions/v42.0.0/sdk/constants/#constantsgetwebviewuseragentasync can be used.