### PR TITLE
feat(campaign): Add campaign optional param to Event tracking

### DIFF
--- a/src/MatomoTracker.js
+++ b/src/MatomoTracker.js
@@ -91,13 +91,15 @@ class MatomoTracker {
    *
    * {String} `value` - The event value. Must be a float or integer value (numeric), not a string.
    *
+   * {String} `campaign` - The event related campaign.
+   *
    * {Object} `userInfo` - Optional data used for tracking different user info, see https://developer.matomo.org/api-reference/tracking-api#optional-user-info.
    */
-  trackEvent({ category, action, name, value, userInfo = {} }) {
+  trackEvent({ category, action, name, value, campaign, userInfo = {} }) {
     if (!category) throw new Error('Error: category is required.');
     if (!action) throw new Error('Error: action is required.');
 
-    return this.track({ e_c: category, e_a: action, e_n: name, e_v: value, ...userInfo });
+    return this.track({ e_c: category, e_a: action, e_n: name, e_v: value, mtm_campaign: campaign, ...userInfo });
   }
 
   /**


### PR DESCRIPTION
**This PR adds a campaign optional parameter to the Event tracking function of `MatomoTracker.js`**

In order to track an advertisement campaign, we should sent alongside any request to matomo a campaign parameter. For instance if I put an Ad that redirects to my application through a universal deep link. It should open my app and redirect to the route of my offer Screen. Then I can send a tracking event to matomo. Although I should be able to know if I came from the Ad or if the user went through the application to find the offer. In which case I do not have any campaign.

- When I come from an Ad, this new parameter is named `mtm_campaign`
- It should be optional
- More about [Matomo Marketing](https://fr.matomo.org/guide/reports/acquisition-and-marketing-channels/)
- More about [Matomo Google Ads](https://fr.matomo.org/blog/2017/12/track-google-ads-campaigns-matomo/)
- Do I need to do something with declaration [@types](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/matomo-tracker-react-native)?

Happy Merging